### PR TITLE
docs: fix text-to-sql demo typos

### DIFF
--- a/examples/text-to-sql-agent/DEMO.md
+++ b/examples/text-to-sql-agent/DEMO.md
@@ -107,7 +107,7 @@ this gives us a nice template to build the application. Let's add some placholde
 </div>
 ```
 
-You could dissect this into seperate components if you want to.
+You could dissect this into separate components if you want to.
 
 also open `globals.css` and remove everything besides:
 
@@ -123,7 +123,7 @@ there are a lot of different ways to use langgraph with different llm providers,
 
 https://ollama.com/
 
-download and install, you can run (in a seperate terminal tab or window) the command for ollama:
+download and install, you can run (in a separate terminal tab or window) the command for ollama:
 
 ```
 ollama run llama3.2


### PR DESCRIPTION
## Problem
The text-to-sql agent demo contains two instances of the typo `seperate`.

## Solution
Correct both occurrences to `separate`.

## Validation
- `git diff --check`
- Verified `seperate` no longer appears in `examples/text-to-sql-agent/DEMO.md`

## Confidence
85/100 — docs/typo fix in an AI agent example. The misspelling and replacement are unambiguous, and the diff only changes prose.